### PR TITLE
README.md: Open only necessary ports in the Docker command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Once the Docker image is downloaded, you can start the container to run the serv
 cd ./bc2rome
 ```
 ```
-sudo docker container run -p 19026:19026/tcp -p 19021:19021/tcp -p 19567:19567/udp -p 18390:18390/udp -p 5900:5900/tcp -p 80:80/tcp -p 48888:48888/tcp -v .\Instance\bc2rome/Instance:/project/R34_Full/Instance" russianvivi/bc2rome:latest```
-
+sudo docker container run -p 19567:19567/udp -p 5900:5900/tcp -p 48888:48888/tcp -v .\Instance\bc2rome/Instance:/project/R34_Full/Instance" russianvivi/bc2rome:latest
 ```
+
 It may be that some distributions need the absolute path
 ```
-sudo docker container run -p 19026:19026/tcp -p 19021:19021/tcp -p 19567:19567/udp -p 18390:18390/udp -p 5900:5900/tcp -p 80:80/tcp -p 48888:48888/tcp -v "<absolutePath>bc2rome/Instance:/project/R34_Full/Instance" russianvivi/bc2rome:latest ```
+sudo docker container run -p 19567:19567/udp -p 5900:5900/tcp -p 48888:48888/tcp -v "<absolutePath>bc2rome/Instance:/project/R34_Full/Instance" russianvivi/bc2rome:latest
 ```
 
 To determ the container id run:


### PR DESCRIPTION
Only the VNC port, configured game port (19567), and Rcon port (48888) have something listening on them. The rest of the ports in the README are unnecessary.

You can verify this by installing the `net-tools` package and running `netstat -tulpn` inside the container.